### PR TITLE
Corrected .github/CONTENTS.md

### DIFF
--- a/.github/CONTENTS.md
+++ b/.github/CONTENTS.md
@@ -2,10 +2,10 @@
 
 This directory contains supporting files for GitHub repository use. The structure and contents of the directory are as follows:
 
-* [CODEOWNERS](CODEOWNERS): Defines which individuals are responsible for code in this repository. See [GitHub code owners](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners).
-* [dependabot.yml](dependabot.yml): Configures [Github Dependabot](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates) to manage security and version updates.
+* [CODEOWNERS](CODEOWNERS): Defines which individuals are responsible for code in this repository. See [GitHub code owners documentation](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners).
+* [dependabot.yml](dependabot.yml): Configures [GitHub Dependabot](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates) to manage security and version updates.
 * [ISSUE_TEMPLATE](ISSUE_TEMPLATE): This directory contains several templates for creating new issues in GitHub.
-* [issue_template.md](issue_template.md): Default issue template.
-* [labels.json](labels.json): Configures the issue labels used by this repository. This is supported by the [labels workflow](workflows/labels.yml).
-* [PULL_REQUEST_TEMPLATE.md](issue_template.md): This file contains a template to be filled out for each GitHub pull request by the person submitting it.
-* [workflows](workflows): The configured [GHitHub actions workflows](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions) for this repository.
+* [issue_template.md](issue_template.md): The default issue template, used when a new issue is created without selecting a specific template.
+* [labels.json](labels.json): Configures the issue labels used by this repository, which are applied by the [labels workflow](workflows/labels.yml).
+* [PULL_REQUEST_TEMPLATE.yaml](PULL_REQUEST_TEMPLATE.yaml): Contains a template for pull requests, to be filled out by the person submitting it.
+* [workflows](workflows): The directory containing configured [GitHub Actions workflows](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions) for this repository.


### PR DESCRIPTION
# Committer Notes

I've reviewed the .github/CONTENTS.md file you provided. There are a few issues and inconsistencies in links and descriptions that need correction. Here's the revised version with correct links and updated descriptions:

## All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/usnistgov/vulntology/blob/main/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/vulntology/pulls) for the same update/change?
- [ ] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain dedication](https://creativecommons.org/publicdomain/zero/1.0/).

## For Changes

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [x] Have you updated all [website](https://pages.nist.gov/vulntology) and readme documentation affected by the changes you made? Changes to the website can be made in the `website/content` directory of your branch.
